### PR TITLE
Add a Claim model

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 ruby File.read(".ruby-version").strip
 
 gem "bootsnap", ">= 1.4.2"
+gem "composite_primary_keys", "~> 12.0.0"
 gem "pg"
 gem "puma", "~> 4.1"
 gem "rails", "~> 6.0.3", ">= 6.0.3.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,8 @@ GEM
     builder (3.2.4)
     byebug (11.1.3)
     coderay (1.1.3)
+    composite_primary_keys (12.0.2)
+      activerecord (~> 6.0.0)
     concurrent-ruby (1.1.6)
     crass (1.0.6)
     diff-lcs (1.4.4)
@@ -218,6 +220,7 @@ DEPENDENCIES
   awesome_print
   bootsnap (>= 1.4.2)
   byebug
+  composite_primary_keys (~> 12.0.0)
   dotenv-rails
   factory_bot_rails
   listen (~> 3.2)

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -1,0 +1,3 @@
+class Claim < ApplicationRecord
+  self.primary_keys = :subject_identifier, :claim_identifier
+end


### PR DESCRIPTION
ActiveRecord doesn't support composite primary keys out of the box, so
we need a model with this gem enabled.