### PR TITLE
Give :account_manager_access read access to test attribute

### DIFF
--- a/app/lib/permissions.rb
+++ b/app/lib/permissions.rb
@@ -9,7 +9,7 @@ module Permissions
       begin
         scopes = load_scopes_from_yaml[:read_scopes]
         scopes.transform_values! { |vs| vs.map(&:to_sym) }
-        enable_test_scopes? ? scopes.merge(TEST_CLAIM_NAME => [TEST_READ_SCOPE]) : scopes
+        enable_test_scopes? ? scopes.merge(TEST_CLAIM_NAME => [TEST_READ_SCOPE, :account_manager_access]) : scopes
       end
   end
 


### PR DESCRIPTION
This is so we can display this in the profile page during local
development.

---

[Trello card](https://trello.com/c/ALNNB4Ay/154-prototype-oauth-oidc-flows-for-attribute-service)