### PR TITLE
Update deploy task to use latest cf-cli image

### DIFF
--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -3,7 +3,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/cf-cli
-    tag: 5b44bd954693937ddd07ee6c9e113923bc620aed
+    tag: e1ffec0d1940706f157a8c1e0ab8131b7084fa1c
 inputs:
   - name: git-main
     path: src
@@ -23,8 +23,8 @@ run:
       cf api "$CF_API"
       cf auth
       cf t -o "$CF_ORG" -s "$CF_SPACE"
-      cf v3-create-app $CF_APP_NAME || true
-      cf v3-apply-manifest -f manifest.yml
+      cf create-app $CF_APP_NAME || true
+      cf apply-manifest -f manifest.yml
       cf set-env $CF_APP_NAME CF_STARTUP_TIMEOUT "$CF_STARTUP_TIMEOUT"
       cf set-env $CF_APP_NAME ACCOUNT_MANAGER_TOKEN "$ACCOUNT_MANAGER_TOKEN"
       cf set-env $CF_APP_NAME ACCOUNT_MANAGER_URL "$ACCOUNT_MANAGER_URL"
@@ -33,5 +33,5 @@ run:
       cf set-env $CF_APP_NAME SENTRY_DSN "$SENTRY_DSN"
       cf set-env $CF_APP_NAME SENTRY_CURRENT_ENV "$CF_SPACE"
 
-      cf v3-zdt-push $CF_APP_NAME --wait-for-deploy-complete --no-route
+      cf push $CF_APP_NAME --strategy rolling
       cf map-route $CF_APP_NAME london.cloudapps.digital --hostname "$HOSTNAME"


### PR DESCRIPTION
> `v3` prefixes have been removed, since the commands now use CAPI v3
> by default.

> This command [`v3-zdt-push`] is removed. Instead, use `--strategy
> rolling` flag with `cf push`.

https://docs.cloudfoundry.org/cf-cli/v7.html