### PR TITLE
Fix column name in migration

### DIFF
--- a/db/migrate/20200814135809_use_boolean_for_email_verification_claim.rb
+++ b/db/migrate/20200814135809_use_boolean_for_email_verification_claim.rb
@@ -1,7 +1,7 @@
 class UseBooleanForEmailVerificationClaim < ActiveRecord::Migration[6.0]
   def up
     Claim.where(claim_identifier: "3a683bee-24a7-4ada-88af-5bfc32a40388").each do |claim|
-      claim.update!(claim_value_jsonb: claim.claim_value == "true")
+      claim.update!(claim_value: claim.claim_value == "true")
     end
   end
 


### PR DESCRIPTION
There is a typo in the migration introduced by #16.

Didn't catch this locally as my database did actually have a `claim_value_jsonb` column from when I was trying something out last week.

Trello card: https://trello.com/c/fMBLbcHw