### PR TITLE
Add an attribute for the transition checker

### DIFF
--- a/app/lib/permissions.rb
+++ b/app/lib/permissions.rb
@@ -13,10 +13,10 @@ module Permissions
       end
   end
 
-  def self.claim_write_scopes
-    @claim_write_scopes ||=
+  def self.claim_readwrite_scopes
+    @claim_readwrite_scopes ||=
       begin
-        scopes = load_scopes_from_yaml[:write_scopes]
+        scopes = load_scopes_from_yaml[:readwrite_scopes]
         scopes.transform_values! { |vs| vs.map(&:to_sym) }
         enable_test_scopes? ? scopes.merge(TEST_CLAIM_NAME => [TEST_WRITE_SCOPE]) : scopes
       end
@@ -53,7 +53,7 @@ module Permissions
   end
 
   def self.any_of_scopes_can_write(claim, scopes)
-    any_of_scopes_can(claim_write_scopes, claim, scopes)
+    any_of_scopes_can(claim_readwrite_scopes, claim, scopes)
   end
 
   def self.any_of_scopes_can(permissions, claim, scopes)

--- a/config/scopes.yml
+++ b/config/scopes.yml
@@ -2,7 +2,7 @@ read_scopes:
   email: ["account_manager_access", "email"]
   email_verified: ["account_manager_access", "email"]
 
-write_scopes:
+readwrite_scopes:
   email: ["account_manager_access"]
   email_verified: ["account_manager_access"]
   transition_checker_state: ["transition_checker"]


### PR DESCRIPTION
We will be using the [GOV.UK Transition Checker](https://github.com/alphagov/finder-frontend/tree/master/app/lib/brexit_checker) as a live example for GOV.UK Accounts.

Since this exists in a frontend app which doesn't have a database, we'll be storing the checker data as an attribute.

This adds an attribute for the transition checker state.  The scopes have been updated, so the account manager has read-only access to this attribute, and a new read/write scope created for the transition checker itself.

There shouldn't need to be any work done in the account manager app, since we won't be displaying this attribute to users in that way.  However, I did create a [branch](https://github.com/alphagov/govuk-account-manager-prototype/pull/new/show-transition-data) to expose the data which allows us to view the data locally without having to open a console.

Trello card: https://trello.com/c/93swZ1DN