### PR TITLE
Add Precommit hooks with detect-secrets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/Yelp/detect-secrets
+    rev: v0.14.3
+    hooks:
+    -   id: detect-secrets
+        args: ['--baseline', '.secrets.baseline']
+        exclude: .*/spec/.*

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,118 @@
+{
+  "custom_plugin_paths": [],
+  "exclude": {
+    "files": null,
+    "lines": null
+  },
+  "generated_at": "2020-09-23T14:09:23Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    ".github/workflows/ci.yml": [
+      {
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 12,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 37,
+        "type": "Basic Auth Credentials"
+      }
+    ],
+    "README.md": [
+      {
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 14,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 20,
+        "type": "Basic Auth Credentials"
+      }
+    ],
+    "concourse/pipeline.yml": [
+      {
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 93,
+        "type": "Basic Auth Credentials"
+      }
+    ],
+    "concourse/tasks/deploy-to-govuk-paas.yml": [
+      {
+        "hashed_secret": "47748b1fd1747e8bff5493fa6c3bcf16d6449969",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 6,
+        "type": "Hex High Entropy String"
+      }
+    ]
+  },
+  "version": "0.14.3",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@ A prototype to store personal data connected with a GOV.UK account, with consent
 
 Use [govuk-accounts-docker](https://github.com/alphagov/govuk-accounts-docker) to run this app together with the Account Manager.
 
+### Pre-commit hooks & Detect Secrets
+
+This repo uses pre-commit hooks (https://pre-commit.com/) and the plugin detect-secrets (https://github.com/Yelp/detect-secrets) to prevent developers deploying secrets.
+Developers working with this repo should ensure they have pre-commit installed on their system before they attempt to commit and push changes.
+
+The [pre-commit project page](https://pre-commit.com/) has instructions on the many ways the tool can be installed.
+If you are using Brew on Mac or linuxbrew, an easy way is to:
+
+```
+brew install pre-commit
+```
+
 ### Running the tests
 
 You don't need govuk-accounts-docker to run the tests, a local postgres database is enough:


### PR DESCRIPTION
Up until now this repo has been private and we've been careful about not committing secrets

However given the potential risk to users once a live prototype is deployed or beyond we want to avoid the risk of human errors with commits

This adds a .secrets.baseline file that contains a record of previous scans by precommit hooks (https://pre-commit.com/) and the detect-secrets plugin (https://github.com/Yelp/detect-secrets). The file contains a record of false-positives previously flagged by the tool, to prevent lots of boring repetition  for future devs just looking to commit their code.