### PR TITLE
Give account_manager_access read access to transition_checker_state

### DIFF
--- a/config/scopes.yml
+++ b/config/scopes.yml
@@ -1,6 +1,7 @@
 read_scopes:
   email: ["account_manager_access", "email"]
   email_verified: ["account_manager_access", "email"]
+  transition_checker_state: ["account_manager_access"]
 
 readwrite_scopes:
   email: ["account_manager_access"]


### PR DESCRIPTION
This is for the service card.

---

[Trello card](https://trello.com/c/3YQDMmfC/294-add-checker-related-links-to-account-manager-if-the-user-has-answered-the-checker)