### PR TITLE
Add Slack notifications for all Concourse pipeline failures

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4,7 +4,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2020-11-02T11:42:44Z",
+  "generated_at": "2020-11-04T11:18:12Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -96,7 +96,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 95,
+        "line_number": 106,
         "type": "Basic Auth Credentials"
       }
     ],

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -65,6 +65,17 @@ jobs:
         params:
           build: git-main-gems-dockerfile
           dockerfile: git-main-gems-dockerfile/concourse/Dockerfile
+        on_failure:
+          put: govuk-slack
+          params:
+            channel: '#govuk-accounts-tech'
+            username: 'Concourse (GOV.UK Accounts)'
+            icon_emoji: ':concourse:'
+            silent: true
+            text: |
+              :kaboom:
+              Test image build for the GOV.UK Attribute Service has failed
+              Failed build: http://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
 
   - name: run-quality-checks
     serial: true
@@ -97,6 +108,18 @@ jobs:
                 bundle exec rails db:setup
                 bundle exec rails db:migrate
                 bundle exec rake
+        on_failure:
+          put: govuk-slack
+          params:
+            channel: '#govuk-accounts-tech'
+            username: 'Concourse (GOV.UK Accounts)'
+            icon_emoji: ':concourse:'
+            silent: true
+            text: |
+              :kaboom:
+              Quality checks for the GOV.UK Attribute Service have failed
+              Failed build: http://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
+
   - name: deploy-app-staging
     serial: true
     plan:


### PR DESCRIPTION
We've previously missed failures because they occur before the deployment part of the pipeline.