### PR TITLE
Add splunk to PaaS manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -5,3 +5,4 @@ applications:
   memory: 2G
   services:
     - govuk-attribute-service-postgres
+    - splunk-ssl-drain


### PR DESCRIPTION
We're up to [here](https://github.com/alphagov/paas-csls-splunk-broker/blob/master/docs/user-guide.md#bind-a-splunk-service-to-your-apps-using-an-app-manifest) in the guidance