### PR TITLE
Remove separate rubocop CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,6 @@ jobs:
           bundle config path tmp/bundle
           bundle install --jobs 4 --retry 3
 
-      - run: bundle exec rubocop
-
       - env:
           RAILS_ENV: test
           TEST_DATABASE_URL: "postgresql://postgres:postgres@localhost/accounts"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -71,7 +71,7 @@
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 43,
+        "line_number": 41,
         "type": "Basic Auth Credentials"
       }
     ],


### PR DESCRIPTION
We already run this as part of `bundle exec rake`.