### PR TITLE
Show total & percentage in transition checker report

### DIFF
--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -2,13 +2,15 @@ namespace :report do
   namespace :transition_checker do
     desc "Check how many users have a criteria key"
     task :count_criteria, %i[key] => :environment do |_t, args|
-      count = Claim
-        .where(claim_identifier: "46be4251-abbb-4688-bb1e-4efe6284a1c5")
-        .pluck(:claim_value)
-        .select { |cv| cv["criteria_keys"].include? args[:key] }
-        .count
+      Claim.transaction do
+        all_claims = Claim.where(claim_identifier: "46be4251-abbb-4688-bb1e-4efe6284a1c5")
+        matching_claims = all_claims.pluck(:claim_value).select { |cv| cv["criteria_keys"].include? args[:key] }
 
-      puts "#{args[:key]}: #{count}"
+        total = all_claims.count
+        matching = matching_claims.count
+
+        puts "#{args[:key]}: #{matching} / #{total} (#{(matching.fdiv(total) * 100).round(2)}%)"
+      end
     end
   end
 end


### PR DESCRIPTION
The raw number isn't useful in isolation.

I've wrapped this in a transaction so all_claims and matching_claims
see consistent data, even if someone signs up or updates their answers
while this task is running.