### PR TITLE
Add timestamps to the claims table

### DIFF
--- a/db/migrate/20210119140925_add_timestamps_to_claims.rb
+++ b/db/migrate/20210119140925_add_timestamps_to_claims.rb
@@ -1,0 +1,5 @@
+class AddTimestampsToClaims < ActiveRecord::Migration[6.0]
+  def change
+    add_timestamps :claims, default: -> { 'now()' }, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_14_135809) do
+ActiveRecord::Schema.define(version: 2021_01_19_140925) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,6 +19,8 @@ ActiveRecord::Schema.define(version: 2020_08_14_135809) do
     t.string "subject_identifier", null: false
     t.uuid "claim_identifier", null: false
     t.jsonb "claim_value"
+    t.datetime "created_at", precision: 6, default: -> { "now()" }, null: false
+    t.datetime "updated_at", precision: 6, default: -> { "now()" }, null: false
     t.index ["claim_identifier"], name: "index_claims_on_claim_identifier"
     t.index ["subject_identifier"], name: "index_claims_on_subject_identifier"
   end


### PR DESCRIPTION
This may be useful in the future; eg making it possible to get a
report of attributes which have been changes in a certain timeframe.