### PR TITLE
Implement an endpoint to set multiple attributes

### DIFF
--- a/app/controllers/v1/bulk_attributes_controller.rb
+++ b/app/controllers/v1/bulk_attributes_controller.rb
@@ -1,0 +1,23 @@
+class V1::BulkAttributesController < ApplicationController
+  before_action :authenticate_token!
+
+  rescue_from ActionController::ParameterMissing do
+    head :bad_request
+  end
+
+  def update
+    claims = params.fetch(:attributes).permit!.to_h.symbolize_keys
+
+    head :forbidden and return unless claims.keys.all? { |claim_name| can_write?(claim_name) }
+
+    claim_hashes = claims.map do |claim_name, value|
+      Claim.upsert!(
+        subject_identifier: @token[:true_subject_identifier],
+        claim_identifier: Permissions.name_to_uuid(claim_name),
+        claim_value: value,
+      ).to_anonymous_hash
+    end
+
+    render json: claim_hashes
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
 
   namespace :v1 do
     resources :attributes, only: %i[show update]
+    post "/attributes", to: "bulk_attributes#update"
     delete "/attributes/all", to: "all_attributes#destroy"
 
     namespace :report do

--- a/spec/fixtures/scopes.yml
+++ b/spec/fixtures/scopes.yml
@@ -1,8 +1,11 @@
 read_scopes:
   test_claim: ["account_manager_access", "test_scope_read"]
+  test_claim_2: ["account_manager_access", "test_scope_read_2"]
 
 readwrite_scopes:
   test_claim: ["test_scope_write"]
+  test_claim_2: ["test_scope_write_2"]
 
 claims:
   test_claim: "00000000-0000-0000-0000-000000000000"
+  test_claim_2: "00000000-0000-0000-0000-000000000002"

--- a/spec/requests/v1/bulk_attributes_spec.rb
+++ b/spec/requests/v1/bulk_attributes_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe "/v1/attributes" do
+  let(:token_scopes) { [] }
+
+  let(:token_hash) do
+    {
+      true_subject_identifier: 42,
+      pairwise_subject_identifier: "aaabbbccc",
+      scopes: token_scopes,
+    }
+  end
+
+  let(:params) do
+    {
+      attributes: {
+        test_claim: "new value 1",
+        test_claim_2: "new value 2",
+      },
+    }
+  end
+
+  before { stub_token_response token_hash }
+
+  describe "POST" do
+    context "the token has permissions to write all the claims" do
+      let(:token_scopes) { %w[test_scope_write test_scope_write_2] }
+
+      it "writes the claims" do
+        expect { post "/v1/attributes", headers: token_headers, params: params }.to(change { Claim.count })
+        expect(response).to be_successful
+        expect(JSON.parse(response.body)).to eq([
+          { "claim_name" => "test_claim", "claim_value" => "new value 1" },
+          { "claim_name" => "test_claim_2", "claim_value" => "new value 2" },
+        ])
+      end
+    end
+
+    context "the token has permissions to write some of the claims" do
+      let(:token_scopes) { %w[test_scope_write] }
+
+      it "does not grant write access" do
+        expect { post "/v1/attributes", headers: token_headers, params: params }.to_not(change { Claim.count })
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "attributes parameter is unset" do
+      let(:params) { {} }
+
+      it "returns 400" do
+        post "/v1/attributes", headers: token_headers, params: params
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We can use this in the RemoteUserInfo.update_profile! method in
account-manager to set both the `email` and `email_verified`
attributes in one fell swoop, which will reduce the total number of
network round-trips from 4 (2 requests to attribute-service, each of
which makes a request to account-manager to check the token) to 2.