### PR TITLE
Revert non-spec parts of #104

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,15 +14,15 @@ class ApplicationController < ActionController::API
         scopes: token_json["scopes"].map(&:to_sym),
       }
     rescue RestClient::Forbidden, RestClient::NotFound, RestClient::Gone
-      head :unauthorized
+      head 401
       return
     rescue RestClient::RequestFailed, JSON::ParserError, URI::InvalidURIError => e
       Raven.capture_exception(e)
-      head :internal_server_error
+      head 500
       return
     end
 
-    head :unauthorized unless @token
+    head 401 unless @token
   end
 
   def can_read?(claim_name)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,12 +24,4 @@ class ApplicationController < ActionController::API
 
     head 401 unless @token
   end
-
-  def can_read?(claim_name)
-    !@token.nil? && Permissions.any_of_scopes_can_read(claim_name, @token[:scopes])
-  end
-
-  def can_write?(claim_name)
-    !@token.nil? && Permissions.any_of_scopes_can_write(claim_name, @token[:scopes])
-  end
 end

--- a/app/controllers/oidc/user_info_controller.rb
+++ b/app/controllers/oidc/user_info_controller.rb
@@ -2,11 +2,25 @@ class Oidc::UserInfoController < ApplicationController
   before_action :authenticate_token!
 
   def show
-    oidc_response = { sub: @token[:pairwise_subject_identifier] }
+    oidc_response = { sub: pairwise_subject_identifier }
 
     render json: Claim
-             .where(subject_identifier: @token[:true_subject_identifier])
-             .select { |c| can_read? c.claim_name }
+             .where(subject_identifier: subject_identifier)
+             .select { |c| Permissions.any_of_scopes_can_read(c.claim_name, token_scopes) }
              .each_with_object(oidc_response) { |c, hsh| hsh[c.claim_name] = c.claim_value }
+  end
+
+private
+
+  def subject_identifier
+    @token[:true_subject_identifier]
+  end
+
+  def pairwise_subject_identifier
+    @token[:pairwise_subject_identifier]
+  end
+
+  def token_scopes
+    @token[:scopes]
   end
 end

--- a/app/controllers/v1/all_attributes_controller.rb
+++ b/app/controllers/v1/all_attributes_controller.rb
@@ -2,7 +2,7 @@ class V1::AllAttributesController < ApplicationController
   before_action :authenticate_token!
 
   def destroy
-    head :forbidden and return unless @token[:scopes].include?(Permissions::DELETE_SCOPE)
+    head :unauthorized and return unless @token[:scopes].include?(Permissions::DELETE_SCOPE)
 
     Claim.where(subject_identifier: @token[:true_subject_identifier]).destroy_all
 

--- a/app/controllers/v1/all_attributes_controller.rb
+++ b/app/controllers/v1/all_attributes_controller.rb
@@ -2,10 +2,23 @@ class V1::AllAttributesController < ApplicationController
   before_action :authenticate_token!
 
   def destroy
-    head 401 and return unless @token[:scopes].include?(Permissions::DELETE_SCOPE)
+    unless token_scopes.include? Permissions::DELETE_SCOPE
+      head 401
+      return
+    end
 
-    Claim.where(subject_identifier: @token[:true_subject_identifier]).destroy_all
+    Claim.where(subject_identifier: subject_identifier).destroy_all
 
     head 200
+  end
+
+private
+
+  def subject_identifier
+    @token[:true_subject_identifier]
+  end
+
+  def token_scopes
+    @token[:scopes]
   end
 end

--- a/app/controllers/v1/all_attributes_controller.rb
+++ b/app/controllers/v1/all_attributes_controller.rb
@@ -2,10 +2,10 @@ class V1::AllAttributesController < ApplicationController
   before_action :authenticate_token!
 
   def destroy
-    head :unauthorized and return unless @token[:scopes].include?(Permissions::DELETE_SCOPE)
+    head 401 and return unless @token[:scopes].include?(Permissions::DELETE_SCOPE)
 
     Claim.where(subject_identifier: @token[:true_subject_identifier]).destroy_all
 
-    head :ok
+    head 200
   end
 end

--- a/app/controllers/v1/attributes_controller.rb
+++ b/app/controllers/v1/attributes_controller.rb
@@ -2,26 +2,26 @@ class V1::AttributesController < ApplicationController
   before_action :authenticate_token!
 
   rescue_from KeyError do
-    head :not_found
+    head 404
   end
 
   rescue_from ActiveRecord::RecordNotFound do
-    head :not_found
+    head 404
   end
 
   rescue_from ActionController::ParameterMissing do
-    head :bad_request
+    head 400
   end
 
   def show
-    head :unauthorized and return unless can_read?(claim_name)
+    head 401 and return unless can_read?(claim_name)
 
     claim = Claim.find_claim(subject_identifier: subject_identifier, claim_identifier: claim_identifier)
     render json: claim.to_anonymous_hash
   end
 
   def update
-    head :unauthorized and return unless can_write?(claim_name)
+    head 401 and return unless can_write?(claim_name)
 
     claim = Claim.upsert!(subject_identifier: subject_identifier, claim_identifier: claim_identifier, claim_value: JSON.parse(params.fetch(:value)))
     render json: claim.to_anonymous_hash

--- a/app/controllers/v1/attributes_controller.rb
+++ b/app/controllers/v1/attributes_controller.rb
@@ -14,14 +14,20 @@ class V1::AttributesController < ApplicationController
   end
 
   def show
-    head 401 and return unless can_read?(claim_name)
+    unless Permissions.any_of_scopes_can_read(claim_name, token_scopes)
+      head 401
+      return
+    end
 
     claim = Claim.find_claim(subject_identifier: subject_identifier, claim_identifier: claim_identifier)
     render json: claim.to_anonymous_hash
   end
 
   def update
-    head 401 and return unless can_write?(claim_name)
+    unless Permissions.any_of_scopes_can_write(claim_name, token_scopes)
+      head 401
+      return
+    end
 
     claim = Claim.upsert!(subject_identifier: subject_identifier, claim_identifier: claim_identifier, claim_value: JSON.parse(params.fetch(:value)))
     render json: claim.to_anonymous_hash
@@ -31,6 +37,10 @@ private
 
   def subject_identifier
     @token[:true_subject_identifier]
+  end
+
+  def token_scopes
+    @token[:scopes]
   end
 
   def claim_identifier

--- a/app/controllers/v1/attributes_controller.rb
+++ b/app/controllers/v1/attributes_controller.rb
@@ -14,14 +14,14 @@ class V1::AttributesController < ApplicationController
   end
 
   def show
-    head :forbidden and return unless can_read?(claim_name)
+    head :unauthorized and return unless can_read?(claim_name)
 
     claim = Claim.find_claim(subject_identifier: subject_identifier, claim_identifier: claim_identifier)
     render json: claim.to_anonymous_hash
   end
 
   def update
-    head :forbidden and return unless can_write?(claim_name)
+    head :unauthorized and return unless can_write?(claim_name)
 
     claim = Claim.upsert!(subject_identifier: subject_identifier, claim_identifier: claim_identifier, claim_value: JSON.parse(params.fetch(:value)))
     render json: claim.to_anonymous_hash

--- a/app/controllers/v1/bulk_attributes_controller.rb
+++ b/app/controllers/v1/bulk_attributes_controller.rb
@@ -8,7 +8,7 @@ class V1::BulkAttributesController < ApplicationController
   def update
     claims = params.fetch(:attributes).permit!.to_h.symbolize_keys
 
-    head :unauthorized and return unless claims.keys.all? { |claim_name| can_write?(claim_name) }
+    head 401 and return unless claims.keys.all? { |claim_name| can_write?(claim_name) }
 
     claim_hashes = claims.map do |claim_name, value|
       Claim.upsert!(

--- a/app/controllers/v1/bulk_attributes_controller.rb
+++ b/app/controllers/v1/bulk_attributes_controller.rb
@@ -8,7 +8,11 @@ class V1::BulkAttributesController < ApplicationController
   def update
     claims = params.fetch(:attributes).permit!.to_h.symbolize_keys
 
-    head 401 and return unless claims.keys.all? { |claim_name| can_write?(claim_name) }
+    can_write_all = claims.keys.all? do |claim_name|
+      Permissions.any_of_scopes_can_write(claim_name, @token[:scopes])
+    end
+
+    head 401 and return unless can_write_all
 
     claim_hashes = claims.map do |claim_name, value|
       Claim.upsert!(

--- a/app/controllers/v1/bulk_attributes_controller.rb
+++ b/app/controllers/v1/bulk_attributes_controller.rb
@@ -8,7 +8,7 @@ class V1::BulkAttributesController < ApplicationController
   def update
     claims = params.fetch(:attributes).permit!.to_h.symbolize_keys
 
-    head :forbidden and return unless claims.keys.all? { |claim_name| can_write?(claim_name) }
+    head :unauthorized and return unless claims.keys.all? { |claim_name| can_write?(claim_name) }
 
     claim_hashes = claims.map do |claim_name, value|
       Claim.upsert!(

--- a/app/controllers/v1/report/bigquery_controller.rb
+++ b/app/controllers/v1/report/bigquery_controller.rb
@@ -2,7 +2,7 @@ class V1::Report::BigqueryController < ApplicationController
   before_action :authenticate_token!
 
   def create
-    head :unauthorized and return unless @token[:scopes].include?(Permissions::REPORTING_SCOPE)
+    head 401 and return unless @token[:scopes].include?(Permissions::REPORTING_SCOPE)
 
     BigqueryReportExportJob.perform_later
 

--- a/app/controllers/v1/report/bigquery_controller.rb
+++ b/app/controllers/v1/report/bigquery_controller.rb
@@ -2,7 +2,7 @@ class V1::Report::BigqueryController < ApplicationController
   before_action :authenticate_token!
 
   def create
-    head 401 and return unless @token[:scopes].include?(Permissions::REPORTING_SCOPE)
+    head 401 and return unless @token[:scopes] == %i[reporting_access]
 
     BigqueryReportExportJob.perform_later
 

--- a/app/controllers/v1/report/bigquery_controller.rb
+++ b/app/controllers/v1/report/bigquery_controller.rb
@@ -2,7 +2,7 @@ class V1::Report::BigqueryController < ApplicationController
   before_action :authenticate_token!
 
   def create
-    head :forbidden and return unless @token[:scopes].include?(Permissions::REPORTING_SCOPE)
+    head :unauthorized and return unless @token[:scopes].include?(Permissions::REPORTING_SCOPE)
 
     BigqueryReportExportJob.perform_later
 

--- a/lib/permissions.rb
+++ b/lib/permissions.rb
@@ -1,6 +1,5 @@
 module Permissions
   DELETE_SCOPE = :account_manager_access
-  REPORTING_SCOPE = :reporting_access
 
   def self.claim_read_scopes
     @claim_read_scopes ||= load_scopes_from_yaml[:read_scopes].tap do |scopes|

--- a/spec/requests/v1/all_attributes_request_spec.rb
+++ b/spec/requests/v1/all_attributes_request_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe "/v1/attributes/all" do
       context "without permission to delete the claims" do
         let(:token_scopes) { %i[some_other_scope] }
 
-        it "returns 403" do
+        it "returns 401" do
           expect { delete "/v1/attributes/all", headers: token_headers }.to_not(change { Claim.count })
-          expect(response).to have_http_status(:forbidden)
+          expect(response).to have_http_status(:unauthorized)
         end
       end
     end

--- a/spec/requests/v1/attributes_request_spec.rb
+++ b/spec/requests/v1/attributes_request_spec.rb
@@ -56,9 +56,9 @@ RSpec.describe "/v1/attributes/:id" do
       end
 
       context "the token does not have permission" do
-        it "returns a 403" do
+        it "returns a 401" do
           get "/v1/attributes/test_claim", headers: token_headers
-          expect(response).to have_http_status(:forbidden)
+          expect(response).to have_http_status(:unauthorized)
         end
       end
     end
@@ -104,14 +104,14 @@ RSpec.describe "/v1/attributes/:id" do
 
         it "does not grant write access" do
           put "/v1/attributes/test_claim", headers: token_headers, params: params
-          expect(response).to have_http_status(:forbidden)
+          expect(response).to have_http_status(:unauthorized)
         end
       end
 
       context "the token does not have permission" do
-        it "returns a 403" do
+        it "returns a 401" do
           put "/v1/attributes/test_claim", headers: token_headers, params: params
-          expect(response).to have_http_status(:forbidden)
+          expect(response).to have_http_status(:unauthorized)
         end
       end
     end

--- a/spec/requests/v1/bulk_attributes_spec.rb
+++ b/spec/requests/v1/bulk_attributes_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "/v1/attributes" do
 
       it "does not grant write access" do
         expect { post "/v1/attributes", headers: token_headers, params: params }.to_not(change { Claim.count })
-        expect(response).to have_http_status(:forbidden)
+        expect(response).to have_http_status(:unauthorized)
       end
     end
 

--- a/spec/requests/v1/report/bigquery_spec.rb
+++ b/spec/requests/v1/report/bigquery_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe "/v1/report/bigquery" do
     })
   end
 
-  it "returns a 403" do
+  it "returns a 401" do
     post v1_report_bigquery_path, headers: token_headers
-    expect(response).to have_http_status(:forbidden)
+    expect(response).to have_http_status(:unauthorized)
   end
 
   context "with a valid token" do


### PR DESCRIPTION
After deploying #104 we noticed an increase in errors from the transition checker seemingly being given a bad response from the attribute service - trying to use a string as a hash.

Not sure what in the changes would have caused that, but the correlation does seem suspicious.  So let's revert it.