### PR TITLE
Add a migration to correct the invalid claims data

### DIFF
--- a/db/migrate/20210126125230_fix_bulk_json_incident.rb
+++ b/db/migrate/20210126125230_fix_bulk_json_incident.rb
@@ -1,0 +1,13 @@
+class FixBulkJsonIncident < ActiveRecord::Migration[6.0]
+  def up
+    bug_start = Time.zone.parse("2021-01-21 00:00:00")
+    bug_end = Time.zone.parse("2021-01-27 00:00:00")
+
+    Claim.where(updated_at: bug_start..bug_end).map do |claim|
+      parsed = JSON.parse(claim.claim_value)
+      claim.update!(claim_value: parsed)
+    rescue JSON::ParserError
+      # value was already parsed
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_19_140925) do
+ActiveRecord::Schema.define(version: 2021_01_26_125230) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
All claims created with the bulk endpoint will be strings in need of
parsing.  Claims updated through the non-bulk endpoint (transition
checker state set directly by the checker, rather than set by the
account manager as a result of registration) will be stored correctly,
and so will throw an error when we try to parse them.