### PR TITLE
Update msgpack to version 1.4.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,7 +151,7 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)
-    msgpack (1.4.1)
+    msgpack (1.4.2)
     multi_json (1.15.0)
     multipart-post (2.1.1)
     netrc (0.11.0)
@@ -332,4 +332,4 @@ RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.1.4
+   2.2.3


### PR DESCRIPTION
The test image build for the GOV.UK Attribute Service has failed:
https://cd.gds-reliability.engineering/teams/govuk-tools/pipelines/govuk-attribute-service-prototype/jobs/build-tests-image/builds/237

This is the message we're currently seeing:
```
Your bundle is locked to msgpack (1.4.1), but that version could
not be found in any of the sources listed in your Gemfile. If you
haven't changed sources, that means the author of msgpack (1.4.1) has
removed it. You'll need to update your bundle to a version other than
msgpack (1.4.1) that hasn't been removed in order to install.
```

Since msgpack 1.4.2 is available in Rubygems
(https://rubygems.org/gems/msgpack/versions/1.4.2), updating to this
version should solve the problem.