### PR TITLE
Add a show_email_confirmation_reminder attribute

### DIFF
--- a/config/scopes.yml
+++ b/config/scopes.yml
@@ -1,14 +1,17 @@
 read_scopes:
   email: ["account_manager_access", "email"]
   email_verified: ["account_manager_access", "email"]
+  show_email_confirmation_reminder: ["account_manager_access", "email"]
   transition_checker_state: ["account_manager_access"]
 
 readwrite_scopes:
   email: ["account_manager_access"]
   email_verified: ["account_manager_access"]
+  show_email_confirmation_reminder: ["account_manager_access"]
   transition_checker_state: ["transition_checker"]
 
 claims:
   email: "35552825-86c7-4c4a-a9b9-7851e0ff0f7c"
   email_verified: "3a683bee-24a7-4ada-88af-5bfc32a40388"
+  show_email_confirmation_reminder: "537bba1b-f842-4ad7-88b6-9664eab88003"
   transition_checker_state: "46be4251-abbb-4688-bb1e-4efe6284a1c5"


### PR DESCRIPTION
On the "your information" page in the account manager, we show a box
reminding the user to confirm their email address.

This box shows up if the user is not confirmed (in which case the
`email_verified` attribute will be false) OR if the user is
confirmed (in which case the `email_verified` attribute will be true)
BUT they have provided a new email address which they haven't verified
yet.

So to move the "your information" page out of the account manager and
onto GOV.UK, we need a new attribute to handle this second case: the
user has confirmed the email address they registered with, but they
have a new one pending.

---

[Trello card](https://trello.com/c/lIDQNATi/813-implement-the-govuk-account-home-page)