### PR TITLE
Add an endpoint to delete an attribute

### DIFF
--- a/app/controllers/v1/attributes_controller.rb
+++ b/app/controllers/v1/attributes_controller.rb
@@ -27,6 +27,13 @@ class V1::AttributesController < ApplicationController
     render json: claim.to_anonymous_hash
   end
 
+  def destroy
+    head :forbidden and return unless can_write?(claim_name)
+
+    Claim.find_claim(subject_identifier: subject_identifier, claim_identifier: claim_identifier).destroy!
+    head :no_content
+  end
+
 private
 
   def subject_identifier

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,9 +6,9 @@ Rails.application.routes.draw do
   end
 
   namespace :v1 do
-    resources :attributes, only: %i[show update]
-    post "/attributes", to: "bulk_attributes#update"
     delete "/attributes/all", to: "all_attributes#destroy"
+    post "/attributes", to: "bulk_attributes#update"
+    resources :attributes, only: %i[show update destroy]
 
     namespace :report do
       post "/bigquery", to: "bigquery#create"

--- a/spec/requests/v1/all_attributes_request_spec.rb
+++ b/spec/requests/v1/all_attributes_request_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "/v1/attributes/all" do
       before { stub_token_response token_hash }
 
       it "removes all claims belonging to that subject" do
-        expect { delete "/v1/attributes/all", headers: token_headers }.to(change { Claim.count })
+        expect { delete "/v1/attributes/all", headers: token_headers }.to change(Claim, :count).by(-1)
         expect(response).to be_successful
         expect(Claim.where(subject_identifier: claim.subject_identifier)).not_to be_present
       end
@@ -32,7 +32,7 @@ RSpec.describe "/v1/attributes/all" do
         let(:token_scopes) { %i[some_other_scope] }
 
         it "returns 403" do
-          expect { delete "/v1/attributes/all", headers: token_headers }.to_not(change { Claim.count })
+          expect { delete "/v1/attributes/all", headers: token_headers }.to_not change(Claim, :count)
           expect(response).to have_http_status(:forbidden)
         end
       end


### PR DESCRIPTION
This will be useful for the new unconfirmed_email attribute, as we'll
delete that when the user confirms it.

---

[Trello card](https://trello.com/c/nvi8bZct/856-add-unconfirmedemail-attribute)